### PR TITLE
Новые интерфейсы матрицы и вектора. connect to #11

### DIFF
--- a/toop-project/toop-project/src/Matrix/IMatrix.cs
+++ b/toop-project/toop-project/src/Matrix/IMatrix.cs
@@ -3,28 +3,25 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using toop_project.src.Vector;
 
 namespace toop_project.src.Matrix
 {
     interface IMatrix
     {
-        bool InitializeFrom(IMatrix matr);
+        IVector Multiply(IVector x);// A*x
+        IVector TMultiply(IVector x);// At*x
 
-        //public delegate void ProcessElement(int i, int j, double d);
-       // void Run(ProcessElement fun);//Пробежаться по всем ненулевым элементам матрицы
+        IVector LMult(IVector x, bool UseDiagonal);//L*x , Если false, то диагональ нулевая
+        IVector UMult(IVector x, bool UseDiagonal);//U*x, Если false, то диагональ нулевая
 
-        //IVector Multiply(IVector x);
-        //IVector TMultiply(IVector x);
+        IVector LSolve(IVector x);//L-1*x
+        IVector USolve(IVector x);//U-1*x
 
-        //IVector LMult(IVector x,bool UseDiagonal);//L*x , Если false, то диагональ нулевая
-        //IVector UMult(IVector x, bool UseDiagonal);//U*x, Если false, то диагональ нулевая
+        IVector LtSolve(IVector x);//Lt-1*x
+        IVector UtSolve(IVector x);//Ut-1*x
 
-        //IVector LSolve(IVector x, bool UseDiagonal);//L-1*x, Если false, то диагональ единички
-        //IVector USolve(IVector x, bool UseDiagonal);//U-1*x, Если false, то диагональ единички
-
-        //IVector LtSolve(IVector x, bool UseDiagonal);//Lt-1*x Если false, то диагональ единички
-        //IVector UtSolve(IVector x, bool UseDiagonal);//Ut-1*x Если false, то диагональ единички
-        //IVector Diagonal { get; }
+        IVector Diagonal { get; }
         int Size { get; }
     }
 }

--- a/toop-project/toop-project/src/Matrix/IMatrix.cs
+++ b/toop-project/toop-project/src/Matrix/IMatrix.cs
@@ -15,11 +15,14 @@ namespace toop_project.src.Matrix
         IVector LMult(IVector x, bool UseDiagonal);//L*x , Если false, то диагональ нулевая
         IVector UMult(IVector x, bool UseDiagonal);//U*x, Если false, то диагональ нулевая
 
-        IVector LSolve(IVector x);//L-1*x
-        IVector USolve(IVector x);//U-1*x
+		IVector LtMult(IVector x, bool UseDiagonal);//Lt*x , Если false, то диагональ нулевая
+        IVector UtMult(IVector x, bool UseDiagonal);//Ut*x, Если false, то диагональ нулевая
 
-        IVector LtSolve(IVector x);//Lt-1*x
-        IVector UtSolve(IVector x);//Ut-1*x
+        IVector LSolve(IVector x, bool UseDiagonal);//L-1*x
+        IVector USolve(IVector x, bool UseDiagonal);//U-1*x
+
+        IVector LtSolve(IVector x, bool UseDiagonal);//Lt-1*x
+        IVector UtSolve(IVector x, bool UseDiagonal);//Ut-1*x
 
         IVector Diagonal { get; }
         int Size { get; }

--- a/toop-project/toop-project/src/Vector/IVector.cs
+++ b/toop-project/toop-project/src/Vector/IVector.cs
@@ -9,8 +9,11 @@ namespace toop_project.src.Vector
     interface IVector
     {
         double this[int i] { get; set; }
-        double Norm();
-        void Nullify();
+        double Norm();// Вычисление нормы
+        double ScalarMult(IVector vec);// Скалярное умножение векторов
+        IVector SumVectors(IVector vec);// Сложение векторов
+        IVector ConstMult(double x);// Умножение вектора на число
+        void Nullify();// Занулить вектор
         int Size { get; }
     }
 }


### PR DESCRIPTION
Ребятишки, в общем вот че мы с Женей и Ильей нарешали:
1)
Вот эту штуку:
bool InitializeFrom(IMatrix matr);
 //public delegate void ProcessElement(int i, int j, double d);
 // void Run(ProcessElement fun);//Пробежаться по всем ненулевым элементам матрицы
мы удалили за ненадобностью. Run и ProcessElement по причинам, оговоренным в субботу, а InitializeForm - потому что Женя сказал убрать.

2)
В связи с отсутствием операторов (хз, куда вы их там подевали, я че-т упустил этот момент на обсуждении), в интерфейс вектора добавлены функции скалярного произведения, умножения на double скаляр и сложение векторов.

3)
Нам, как в среду, так и сейчас, непонятны те закидоны с bool UseDiagonal, поэтому данная штука оставлена только в LMult(которое L*x), из LSolve и LtSolve эта булевая ерунда убрана. По умолчанию считаем, что диагональ относится к нижнему треугольнику матрицы, как это всегда было на ЧМ.

Данные изменения останутся в силе, ибо *_АЗЪ ЕСМЪ ЦАРЬ, СЛОВО МОЕ ЗАКОН И ДЕЯНИЯ МОИ СВЯТЫ! *_
За сим откланиваюсь, Данил.

P.S. Ну может че и поменяем по вашему усмотрению, не звери же)
